### PR TITLE
Update sxm auth to sxmdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is forked from andrew0 with minimal changes:
 
 * Updated SXM auth cookie name (so that the system actually authenticates now...)
+  * 20240131 And changed it again...
 * Updated AWS cookie name (again, so that it actually authenticates again...)
 * Added -e (--env) parameter to use SXM_USER and SXM_PASS environment variables to override username and password on command line
   * Note: The username and password parameters are still required:  just put something like "user" and "pass".

--- a/sxm.py
+++ b/sxm.py
@@ -26,7 +26,7 @@ class SiriusXM:
         print('{} <SiriusXM>: {}'.format(datetime.datetime.now().strftime('%d.%b %Y %H:%M:%S'), x))
 
     def is_logged_in(self):
-        return 'SXMAUTHNEW' in self.session.cookies
+        return 'SXMDATA' in self.session.cookies
 
     def is_session_authenticated(self):
         return 'AWSALB' in self.session.cookies and 'JSESSIONID' in self.session.cookies


### PR DESCRIPTION
This updates the SXM auth cookie to the new name (20240131).  (See https://github.com/AngellusMortis/sxm-client/issues/8 )